### PR TITLE
Added a custom error that also returns the current url and status code

### DIFF
--- a/ResloveRedirectError.js
+++ b/ResloveRedirectError.js
@@ -1,0 +1,12 @@
+/**
+ * Wraps the resolve redirect error and enriches it with the current url that caused the error
+ */
+class ResolveRedirectError extends Error {
+    constructor(message, statusCode, currentUrl = null) {
+        super(message);
+        this.statusCode = statusCode;
+        this.currentUrl = currentUrl;
+    }
+}
+
+module.exports = ResolveRedirectError;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const ResolveRedirectError = require('./ResloveRedirectError');
 const getResponse = require('./get-response');
 
 module.exports = resolveRedirect;
@@ -16,15 +17,15 @@ function resolveRedirect(url, maxRedirect, callback) {
   return getResponse(currentUrl)
     .then(function handleResponse(response) {
       let done;
-      if (response.statusCode === 404 && response.req.method === 'HEAD'){ // Some Amazon servers return 404 fot HEAD,so we try GET: https://stackoverflow.com/questions/73413321/unshort-amazon-eu-link-using-python
+      if (response.statusCode === 404 && response.req.method === 'HEAD') { // Some Amazon servers return 404 fot HEAD,so we try GET: https://stackoverflow.com/questions/73413321/unshort-amazon-eu-link-using-python
           return getResponse(currentUrl, null, 'GET').then( handleResponse )
       }
       else if (response.statusCode === 301 || response.statusCode === 302) {
         currentUrl = response.headers.location;
         count = count + 1;
-      } else if (response.statusCode < 200 || response.statusCode === 404 || response.statusCode>=500) {
-        throw new Error(`${currentUrl} returned HTTP ${response.statusCode}`)
-      }else {
+      } else if (response.statusCode < 200 || response.statusCode === 404 || response.statusCode >= 500) {
+        throw new ResolveRedirectError(`${currentUrl} returned HTTP ${response.statusCode}`, response.statusCode, currentUrl);
+      } else {
         done = true;
       }
 

--- a/test/resolve-request.js
+++ b/test/resolve-request.js
@@ -29,9 +29,10 @@ test('secure url without redirect', t => {
 });
 
 test('broken url - HTTP 404', async t => {
-  await t.throwsAsync(() =>
-      resolveRedirect('http://feedproxy.google.com/~r/Coroflot/AllJobs/~3/69s2F4RGu-k/Designer'),
-      {instanceOf: Error, message: 'http://feedproxy.google.com/~r/Coroflot/AllJobs/~3/69s2F4RGu-k/Designer returned HTTP 404'});
+  const err = await t.throwsAsync(() => resolveRedirect('http://feedproxy.google.com/~r/Coroflot/AllJobs/~3/69s2F4RGu-k/Designer'));
+  t.is(err.message, 'http://feedproxy.google.com/~r/Coroflot/AllJobs/~3/69s2F4RGu-k/Designer returned HTTP 404');
+  t.is(err.statusCode, 404);
+  t.is(err.currentUrl, 'http://feedproxy.google.com/~r/Coroflot/AllJobs/~3/69s2F4RGu-k/Designer');
 });
 
 test('broken url - malformed URL', async t => {


### PR DESCRIPTION
This PR is the first step to fix the issue raised  [here](https://github.com/vaiden/amazon-asin/issues/19#issue-2082661016)

this will allow extracting the current url even if there are error codes (such as 503) and then extracting the ASIN from it